### PR TITLE
- Add caveat

### DIFF
--- a/man/man1/slecompliancereport.1
+++ b/man/man1/slecompliancereport.1
@@ -52,3 +52,12 @@ The secret AWS API key
 .IP "--verbose"
 Write progress information to
 .I stdout
+.SH CAVEAT
+The implementation uses the
+.I get_available_regions
+API from the
+.I boto3
+implementation. This API produces the result of a hard coded list from the
+.I boto3
+implementation. Therefore, depending on the version of the installed boto3
+package not all available regions may be processed.


### PR DESCRIPTION
  + The boto3 get_available_regions API returns a vlaue based on a hard
    coded list as AWS does not offer a real API for region information.
    This caveat may cause regions to be skipped from inspection. Note
    this condition in the man page.